### PR TITLE
UNDOK-46: Attaching persistent volume to Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     environment:
       - POSTGRES_PASSWORD=dev123
       - POSTGRES_USER=undok
+    volumes:
+      - pg-data:/var/lib/postgresql/data
 
   greenmail:
     container_name: dev-undok-greenmail
@@ -35,3 +37,6 @@ services:
       - ROUNDCUBEMAIL_DEFAULT_PORT=3143       # IMAP port
       - ROUNDCUBEMAIL_SMTP_SERVER=greenmail   # SMTP server - tls:// prefix for STARTTLS, ssl:// for SSL/TLS
       - ROUNDCUBEMAIL_SMTP_PORT=3025          # SMTP port
+
+volumes:
+  pg-data:


### PR DESCRIPTION
Issue seems to have been that the Dockerized Postgres did not have a persistent volume attached. Whenever the container was shut down (eg. `docker-compose down` or simple computer shutdown), the data was lost. 

After attaching the volume, I ran following (manual) tests to verify that the issue is solved

 * Starting the development database: `docker-compose up -D`
 * Create a manual entry in `employers` (to have something in the database): `insert into employers (id, company, position, created_at, updated_at, person_id) values ('974624e5-92d1-4697-9c51-d6f59e9191a8', 'xxx', 'xxx', now(), now(), null)`
 * Start `UndokAt` Application - employer record is still there
 * Stop / Start `UndokAt` Application again - employer record is still there
 * Shutting down development database: `docker-compose down`
 * Running integration tests from the command line `mvn clean verify -Pit`. 
 * The tests themselves fail (probably due to changes to application security - get a lot of `403 FORBIDDEN`.
 * Starting the development database again: `docker-compose up -D`
 *  Employer record is still there